### PR TITLE
correct system font format

### DIFF
--- a/src/llm_core/llm/llama_cpp_compatible.py
+++ b/src/llm_core/llm/llama_cpp_compatible.py
@@ -146,10 +146,9 @@ class LLaVACPPModel(LLaMACPPModel):
         messages = [
             {
                 "role": "system",
-                "content": [{"type": "text", "text": self.system_prompt}],
+                "content": self.system_prompt,
             },
         ]
-
         if history:
             messages += history
 


### PR DESCRIPTION
addresses https://github.com/advanced-stack/py-llm-core/issues/6

correct type is 

```python
class ChatCompletionRequestSystemMessage(TypedDict):
    role: Literal["system"]
    content: Optional[str]
```

https://github.com/abetlen/llama-cpp-python/blob/main/llama_cpp/llama_types.py#L180