### PR TITLE
Fix bug in computing schema context size

### DIFF
--- a/src/llm_core/llm/base.py
+++ b/src/llm_core/llm/base.py
@@ -16,7 +16,7 @@ class LLMBase:
         schema_prompt = ""
 
         if schema:
-            schema_prompt = json.dumps(schema_prompt)
+            schema_prompt = json.dumps(schema)
 
         complete_prompt = [
             self.system_prompt,


### PR DESCRIPTION
The current code is always computing schema_prompt as "".  This can cause problems estimating context length, especially is there is a longer context length.

This fixes it so the correct schema is used. 