### PR TITLE
Support history in sanitize_prompt

### DIFF
--- a/src/llm_core/llm/base.py
+++ b/src/llm_core/llm/base.py
@@ -21,6 +21,7 @@ class LLMBase:
         complete_prompt = [
             self.system_prompt,
             prompt,
+            str(history) if history else "",
             schema_prompt,
         ]
 


### PR DESCRIPTION
sanitize_prompt has a "history" argument, but was ignoring it.  Here, I convert it to a string and include it in the token count.  That's not perfect, but provides a better estimate than ignoring it.